### PR TITLE
Add nodemon to prevent error on 'npm run dev'.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "yargs": "^12.0.2"
   },
   "devDependencies": {
-    "mocha": "^5.2.0"
+    "mocha": "^5.2.0",
+    "nodemon": "^1.19.0"
   }
 }


### PR DESCRIPTION
I received an error when running `npm run dev`. This was directly after cloning.

This PR simply adds `nodemon` to package.json to prevent the error and allow the server to run.